### PR TITLE
ARS-483: Fix Environment header key

### DIFF
--- a/app/uk/gov/hmrc/advancevaluationrulings/connectors/DefaultETMPConnector.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/connectors/DefaultETMPConnector.scala
@@ -50,7 +50,7 @@ class DefaultETMPConnector @Inject() (httpClient: HttpClient, appConfig: AppConf
     val path                   = appConfig.etmpSubscriptionDisplayEndpoint
     val url                    = s"$baseUrl$path"
     val headerCarrierWithToken = headerCarrier.withExtraHeaders(
-      "environment"   -> appConfig.integrationFrameworkEnv,
+      "Environment"   -> appConfig.integrationFrameworkEnv,
       "Authorization" -> s"Bearer ${appConfig.integrationFrameworkToken}",
       "Date"          -> LocalDateTime.now().atOffset(ZoneOffset.UTC).format(dateFormat)
     )


### PR DESCRIPTION
This changes uses `Environment` instead of `environment` for the request header key when making requests to Integration Framework.