### PR TITLE
ARS-483: Log connector error response

### DIFF
--- a/app/uk/gov/hmrc/advancevaluationrulings/connectors/HttpReaderWrapper.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/connectors/HttpReaderWrapper.scala
@@ -60,7 +60,7 @@ trait HttpReaderWrapper[T, E <: BaseError] {
         logger.debug(s"Got response: ${Json.prettyPrint(validJson)}")
         successHandler(validJson)
       case Failure(exception) =>
-        logger.error(s"Failed to serialize upstream json response: ${exception.getMessage}")
+        logger.error(s"Failed to serialize upstream json response: ${response.body}\n ${exception.getMessage}")
         JsonSerializationError(exception).asLeft[T]
     }
 


### PR DESCRIPTION
This change:
- Passes the request headers sent to ETMP explicitly
- Logs the error response from ETMP for debugging