### PR TITLE
ARS-430: Add unique index for applicationNumber

### DIFF
--- a/app/uk/gov/hmrc/advancevaluationrulings/models/ValuationRulingsApplication.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/models/ValuationRulingsApplication.scala
@@ -23,7 +23,6 @@ import uk.gov.hmrc.advancevaluationrulings.models.common.UserAnswers
 import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 
 final case class ValuationRulingsApplication(
-  id: String,
   data: UserAnswers,
   applicationNumber: String,
   lastUpdated: Instant
@@ -36,8 +35,7 @@ object ValuationRulingsApplication {
     import play.api.libs.functional.syntax._
 
     (
-      (__ \ "_id").read[String] and
-        (__ \ "data").read[UserAnswers] and
+      (__ \ "data").read[UserAnswers] and
         (__ \ "applicationNumber").read[String] and
         (__ \ "lastUpdated").read(MongoJavatimeFormats.instantFormat)
     )(ValuationRulingsApplication.apply _)
@@ -48,8 +46,7 @@ object ValuationRulingsApplication {
     import play.api.libs.functional.syntax._
 
     (
-      (__ \ "_id").write[String] and
-        (__ \ "data").write[UserAnswers] and
+      (__ \ "data").write[UserAnswers] and
         (__ \ "applicationNumber").write[String] and
         (__ \ "lastUpdated").write(MongoJavatimeFormats.instantFormat)
     )(unlift(ValuationRulingsApplication.unapply))

--- a/app/uk/gov/hmrc/advancevaluationrulings/repositories/ValuationRulingsRepository.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/repositories/ValuationRulingsRepository.scala
@@ -17,13 +17,11 @@
 package uk.gov.hmrc.advancevaluationrulings.repositories
 
 import scala.concurrent.Future
-
 import uk.gov.hmrc.advancevaluationrulings.models.ValuationRulingsApplication
-
 import com.google.inject.ImplementedBy
 
 @ImplementedBy(classOf[ValuationRulingsRepositoryImpl])
 trait ValuationRulingsRepository {
   def insert(application: ValuationRulingsApplication): Future[Boolean]
-  def getItem(id: String): Future[Option[ValuationRulingsApplication]]
+  def getItems(eoriNumber: String): Future[Seq[ValuationRulingsApplication]]
 }

--- a/app/uk/gov/hmrc/advancevaluationrulings/repositories/ValuationRulingsRepositoryImpl.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/repositories/ValuationRulingsRepositoryImpl.scala
@@ -44,8 +44,7 @@ class ValuationRulingsRepositoryImpl @Inject() (
           Indexes.ascending("data.checkRegisteredDetails.eori"),
           IndexOptions().name("eoriNumberIdx")
         )
-      ),
-      replaceIndexes = true
+      )
     )
     with ValuationRulingsRepository {
 

--- a/app/uk/gov/hmrc/advancevaluationrulings/repositories/ValuationRulingsRepositoryImpl.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/repositories/ValuationRulingsRepositoryImpl.scala
@@ -17,14 +17,11 @@
 package uk.gov.hmrc.advancevaluationrulings.repositories
 
 import javax.inject.{Inject, Singleton}
-
 import scala.concurrent.{ExecutionContext, Future}
-
 import uk.gov.hmrc.advancevaluationrulings.models.ValuationRulingsApplication
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
-
-import org.mongodb.scala.model.{Filters, Indexes, IndexModel, IndexOptions}
+import org.mongodb.scala.model.{Filters, IndexModel, IndexOptions, Indexes}
 
 @Singleton
 class ValuationRulingsRepositoryImpl @Inject() (
@@ -36,10 +33,19 @@ class ValuationRulingsRepositoryImpl @Inject() (
       domainFormat = ValuationRulingsApplication.format,
       indexes = Seq(
         IndexModel(
+          Indexes.ascending("applicationNumber"),
+          IndexOptions().name("applicationNumberIdx").unique(true)
+        ),
+        IndexModel(
           Indexes.descending("lastUpdated"),
           IndexOptions().name("lastUpdatedIdx")
+        ),
+        IndexModel(
+          Indexes.ascending("data.checkRegisteredDetails.eori"),
+          IndexOptions().name("eoriNumberIdx")
         )
-      )
+      ),
+      replaceIndexes = true
     )
     with ValuationRulingsRepository {
 
@@ -49,9 +55,9 @@ class ValuationRulingsRepositoryImpl @Inject() (
       .toFuture()
       .map(_.wasAcknowledged())
 
-  override def getItem(id: String): Future[Option[ValuationRulingsApplication]] =
+  override def getItems(eoriNumber: String): Future[Seq[ValuationRulingsApplication]] =
     collection
-      .find(Filters.equal("_id", id))
-      .headOption()
+      .find(Filters.equal("data.checkRegisteredDetails.eori", eoriNumber))
+      .toFuture()
 
 }

--- a/it/uk/gov/hmrc/advancevaluationrulings/SubmitAnswersEndpointSpec.scala
+++ b/it/uk/gov/hmrc/advancevaluationrulings/SubmitAnswersEndpointSpec.scala
@@ -1,0 +1,35 @@
+package uk.gov.hmrc.advancevaluationrulings
+
+import play.api.libs.json.Json
+import uk.gov.hmrc.advancevaluationrulings.models.common.SubmissionSuccess
+import uk.gov.hmrc.advancevaluationrulings.utils.BaseIntegrationSpec
+
+import generators.ModelGenerators
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class SubmitAnswersEndpointSpec extends BaseIntegrationSpec with ModelGenerators {
+
+  "Submit Answers endpoint" should {
+    "respond with 200 status" in {
+      ScalaCheckPropertyChecks.forAll(valuationRulingsApplicationGen) {
+        valuationRulingsApplication =>
+          val response = wsClient
+            .url(submitAnswersEndpoint)
+            .post(Json.toJson(valuationRulingsApplication))
+            .futureValue
+
+          response.status mustBe 200
+          response.json mustBe Json.toJson(SubmissionSuccess(acknowledged = true))
+      }
+    }
+
+    "respond with 400 status when given an invalid application submission" in {
+      val response = wsClient
+        .url(submitAnswersEndpoint)
+        .post(Json.toJson("{}"))
+        .futureValue
+
+      response.status mustBe 400
+    }
+  }
+}

--- a/it/uk/gov/hmrc/advancevaluationrulings/utils/BaseIntegrationSpec.scala
+++ b/it/uk/gov/hmrc/advancevaluationrulings/utils/BaseIntegrationSpec.scala
@@ -54,6 +54,7 @@ trait BaseIntegrationSpec
 
   val baseUrl               = s"http://localhost:$port"
   val traderDetailsEndpoint = s"$baseUrl/advance-valuation-rulings/trader-details"
+  val submitAnswersEndpoint = s"$baseUrl/advance-valuation-rulings/submit-answers"
 
   override def fakeApplication(): Application =
     GuiceApplicationBuilder()

--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -19,7 +19,6 @@ package generators
 import java.time._
 
 import org.scalacheck.{Gen, Shrink}
-import org.scalacheck.Arbitrary._
 import org.scalacheck.Gen._
 
 trait Generators {

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -150,12 +150,10 @@ trait ModelGenerators extends Generators {
 
   def valuationRulingsApplicationGen: Gen[ValuationRulingsApplication] =
     for {
-      id                <- stringsWithMaxLength(32)
       userAnswers       <- userAnswersGen
       applicationNumber <- stringsWithMaxLength(32)
       localDateTime     <- localDateTimeGen
     } yield ValuationRulingsApplication(
-      id = id,
       data = userAnswers,
       applicationNumber = applicationNumber,
       lastUpdated = localDateTime.toInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS)


### PR DESCRIPTION
This PR adds:
- A unique index to ensure that an applicationNumber is not inserted more than once
- Retrieves a list of applications for a given EORI number
- This will also fix the pipeline failures due to duplicate id key