### PR TITLE
Update old enum to remove pattern match warnings

### DIFF
--- a/app/uk/gov/hmrc/advancevaluationrulings/controllers/ValuationCaseController.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/controllers/ValuationCaseController.scala
@@ -97,7 +97,7 @@ object ValuationCaseController {
     implicit val fmt: OFormat[AssignCaseRequest] = Json.format[AssignCaseRequest]
   }
 
-  case class RejectCaseRequest(reference: String, reason: RejectReason.Value, attachment: Attachment, note: String)
+  case class RejectCaseRequest(reference: String, reason: RejectReason, attachment: Attachment, note: String)
 
   object RejectCaseRequest {
     implicit val fmt: OFormat[RejectCaseRequest] = Json.format[RejectCaseRequest]

--- a/app/uk/gov/hmrc/advancevaluationrulings/models/RejectReason.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/models/RejectReason.scala
@@ -16,21 +16,16 @@
 
 package uk.gov.hmrc.advancevaluationrulings.models
 
-import play.api.libs.json.{Format, Json}
-import uk.gov.hmrc.advancevaluationrulings.models
+import enumeratum.{Enum, EnumEntry, PlayJsonEnum}
 
-object RejectReason extends Enumeration {
-  type RejectReason = Value
-  val APPLICATION_WITHDRAWN, ATAR_RULING_ALREADY_EXISTS, DUPLICATE_APPLICATION, NO_INFO_FROM_TRADER, OTHER = Value
+sealed abstract class RejectReason(override val entryName: String) extends EnumEntry
 
-  def format(reason: RejectReason): String =
-    reason match {
-      case APPLICATION_WITHDRAWN      => "Application withdrawn"
-      case ATAR_RULING_ALREADY_EXISTS => "ATaR ruling already exists"
-      case DUPLICATE_APPLICATION      => "Duplicate application"
-      case NO_INFO_FROM_TRADER        => "No information from trader"
-      case OTHER                      => "Other"
-    }
+object RejectReason extends Enum[RejectReason] with PlayJsonEnum[RejectReason] {
+  val values: IndexedSeq[RejectReason] = findValues
 
-  implicit val fmt: Format[models.RejectReason.Value] = Json.formatEnum(this)
+  case object APPLICATION_WITHDRAWN extends RejectReason("Application withdrawn")
+  case object ATAR_RULING_ALREADY_EXISTS extends RejectReason("ATaR ruling already exists")
+  case object DUPLICATE_APPLICATION extends RejectReason("Duplicate application")
+  case object NO_INFO_FROM_TRADER extends RejectReason("No information from trader")
+  case object OTHER extends RejectReason("Other")
 }

--- a/app/uk/gov/hmrc/advancevaluationrulings/services/ValuationCaseService.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/services/ValuationCaseService.scala
@@ -40,7 +40,7 @@ trait ValuationCaseService {
 
   def findByAssignee(assignee: String): Future[List[ValuationCase]]
 
-  def rejectCase(reference: String, reason: RejectReason.Value, attachment: Attachment, note: String): Future[Long]
+  def rejectCase(reference: String, reason: RejectReason, attachment: Attachment, note: String): Future[Long]
 }
 
 class MongoValuationCaseService @Inject() (repository: ValuationCaseRepository)(implicit ec: ExecutionContext) extends ValuationCaseService {
@@ -64,7 +64,7 @@ class MongoValuationCaseService @Inject() (repository: ValuationCaseRepository)(
 
   override def assignCase(reference: String, caseWorker: CaseWorker): Future[Long] = repository.assignCase(reference, caseWorker)
 
-  override def rejectCase(reference: String, reason: RejectReason.Value, attachment: Attachment, note: String): Future[Long] = {
+  override def rejectCase(reference: String, reason: RejectReason, attachment: Attachment, note: String): Future[Long] = {
      def updateItem(item: ValuationCase) = item.copy(status = CaseStatus.REJECTED, attachments = item.attachments :+ attachment)
      val outcome = for{
        item <- OptionT(findByReference((reference)))

--- a/test/uk/gov/hmrc/advancevaluationrulings/models/RejectReasonSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/models/RejectReasonSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.advancevaluationrulings.models
+
+import play.api.libs.json.Json
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class RejectReasonSpec extends AnyWordSpec with Matchers {
+  "json serialization" should {
+    "form an isomorphism for Application Withdrawn" in {
+      val reason: RejectReason = RejectReason.APPLICATION_WITHDRAWN
+
+      val formatted = Json.toJson(reason)
+      val result    = Json.fromJson[RejectReason](formatted)
+
+      result.get shouldBe reason
+    }
+
+    "form an isomorphism for ATaR ruling already exists" in {
+      val reason: RejectReason = RejectReason.ATAR_RULING_ALREADY_EXISTS
+
+      val formatted = Json.toJson(reason)
+      val result    = Json.fromJson[RejectReason](formatted)
+
+      result.get shouldBe reason
+    }
+
+    "form an isomorphism for Duplicate application" in {
+      val reason: RejectReason = RejectReason.DUPLICATE_APPLICATION
+
+      val formatted = Json.toJson(reason)
+      val result    = Json.fromJson[RejectReason](formatted)
+
+      result.get shouldBe reason
+    }
+
+    "form an isomorphism for No information from trader" in {
+      val reason: RejectReason = RejectReason.NO_INFO_FROM_TRADER
+
+      val formatted = Json.toJson(reason)
+      val result    = Json.fromJson[RejectReason](formatted)
+
+      result.get shouldBe reason
+    }
+
+    "form an isomophism for Other" in {
+      val reason: RejectReason = RejectReason.OTHER
+
+      val formatted = Json.toJson(reason)
+      val result    = Json.fromJson[RejectReason](formatted)
+
+      result.get shouldBe reason
+    }
+
+  }
+
+}


### PR DESCRIPTION
There are more of these raising exhaustivity warnings during compilation. `Enumeration` as a type should ideally be avoided as it is not type safe