### PR TITLE
ARS-732: Make applicationContactDetails optional

### DIFF
--- a/app/uk/gov/hmrc/advancevaluationrulings/models/common/UserAnswers.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/models/common/UserAnswers.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.{Json, OFormat}
 final case class UserAnswers(
   importGoods: Boolean,
   checkRegisteredDetails: RegisteredDetailsCheck,
-  applicationContactDetails: ApplicationContactDetails,
+  applicationContactDetails: Option[ApplicationContactDetails],
   valuationMethod: ValuationMethod,
   isThereASaleInvolved: Option[Boolean],
   isSaleBetweenRelatedParties: Option[Boolean],

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -117,7 +117,7 @@ trait ModelGenerators extends Generators {
     for {
       importGoods                              <- Arbitrary.arbitrary[Boolean]
       registeredDetailsCheck                   <- registeredDetailsCheckGen
-      applicationContactsDetails               <- applicationContactsDetailsGen
+      applicationContactDetails                <- Gen.option(applicationContactsDetailsGen)
       valuationMethod                          <- Gen.oneOf(ValuationMethod.values)
       isThereASaleInvolved                     <- Gen.option(Arbitrary.arbitrary[Boolean])
       isSaleBetweenRelatedParties              <- Gen.option(Arbitrary.arbitrary[Boolean])
@@ -133,7 +133,7 @@ trait ModelGenerators extends Generators {
     } yield UserAnswers(
       importGoods = importGoods,
       checkRegisteredDetails = registeredDetailsCheck,
-      applicationContactDetails = applicationContactsDetails,
+      applicationContactDetails = applicationContactDetails,
       valuationMethod = valuationMethod,
       isThereASaleInvolved = isThereASaleInvolved,
       isSaleBetweenRelatedParties = isSaleBetweenRelatedParties,


### PR DESCRIPTION
This PR makes the `applicationContactDetails` field optional to allow acceptance testing succeed.