### PR TITLE
ARS-784: Add consentToDisclosureOfPersonalData to TraderDetails

### DIFF
--- a/app/uk/gov/hmrc/advancevaluationrulings/models/application/TraderDetail.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/models/application/TraderDetail.scala
@@ -20,6 +20,7 @@ import play.api.libs.json.{Json, OFormat}
 
 final case class TraderDetail(
                                eori: String,
+                               consentToDisclosureOfPersonalData: Boolean,
                                businessName: String,
                                addressLine1: String,
                                addressLine2: Option[String],

--- a/it/uk/gov/hmrc/advancevaluationrulings/repositories/ApplicationRepositorySpec.scala
+++ b/it/uk/gov/hmrc/advancevaluationrulings/repositories/ApplicationRepositorySpec.scala
@@ -20,7 +20,7 @@ class ApplicationRepositorySpec
 
   protected override val repository = new ApplicationRepository(mongoComponent)
 
-  private val trader = TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None)
+  private val trader = TraderDetail("eori", true, "name", "line1", None, None, "postcode", "GB", None)
   private val goodsDetails = GoodsDetails("name", "description", None, None, None)
   private val submissionReference = "submissionReference"
   private val method = MethodOne(None, None, None)

--- a/test/uk/gov/hmrc/advancevaluationrulings/controllers/ApplicationControllerSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/controllers/ApplicationControllerSpec.scala
@@ -48,7 +48,7 @@ class ApplicationControllerSpec extends AnyFreeSpec with Matchers with OptionVal
 
   private val applicantEori = "applicantEori"
   private val atarEnrolment = Enrolments(Set(Enrolment("HMRC-ATAR-ORG", Seq(EnrolmentIdentifier("EORINumber", applicantEori)), "Activated")))
-  private val trader = TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None)
+  private val trader = TraderDetail("eori", true, "name", "line1", None, None, "postcode", "GB", None)
   private val goodsDetails = GoodsDetails("name", "description", None, None, None)
   private val submissionReference = "submissionReference"
   private val method = MethodOne(None, None, None)

--- a/test/uk/gov/hmrc/advancevaluationrulings/models/application/ApplicationRequestSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/models/application/ApplicationRequestSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.advancevaluationrulings.models.application
 
 import play.api.libs.json.{JsSuccess, Json}
 import generators.Generators
+import org.scalacheck.Arbitrary
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
@@ -61,10 +62,13 @@ class ApplicationRequestSpec extends AnyWordSpec with Matchers with ScalaCheckPr
 object ApplicationRequestSpec extends Generators {
   val randomString: String = stringsWithMaxLength(8).sample.getOrElse("random")
 
+  val randomBoolean: Boolean = Arbitrary.arbitrary[Boolean].sample.getOrElse(true)
+
   val draftId: DraftId = DraftId(0)
 
   val eoriDetails = TraderDetail(
     eori = randomString,
+    consentToDisclosureOfPersonalData = randomBoolean,
     businessName = randomString,
     addressLine1 = randomString,
     addressLine2 = Some(randomString),
@@ -106,6 +110,7 @@ object ApplicationRequestSpec extends Generators {
     |"draftId": "$draftId",
     |"trader": {
     |  "eori": "$randomString",
+    |  "consentToDisclosureOfPersonalData": $randomBoolean,
     |  "businessName": "$randomString",
     |  "addressLine1": "$randomString",
     |  "addressLine2": "$randomString",

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/ApplicationServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/ApplicationServiceSpec.scala
@@ -23,13 +23,11 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import play.api.test.FakeRequest
 import uk.gov.hmrc.advancevaluationrulings.models.{Done, DraftId}
 import uk.gov.hmrc.advancevaluationrulings.models.application._
 import uk.gov.hmrc.advancevaluationrulings.repositories.{ApplicationRepository, CounterRepository}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.objectstore.client.Path
-import uk.gov.hmrc.advancevaluationrulings.controllers.actions.IdentifierRequest
 import uk.gov.hmrc.advancevaluationrulings.models.audit.ApplicationSubmissionEvent
 import uk.gov.hmrc.auth.core.{AffinityGroup, Assistant}
 import uk.gov.hmrc.advancevaluationrulings.models.audit.AuditMetadata
@@ -48,7 +46,7 @@ class ApplicationServiceSpec extends AnyFreeSpec with Matchers with MockitoSugar
   private val mockAuditService = mock[AuditService]
   private val fixedInstant = Instant.now
   private val fixedClock = Clock.fixed(fixedInstant, ZoneId.systemDefault())
-  private val trader = TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None)
+  private val trader = TraderDetail("eori", true, "name", "line1", None, None, "postcode", "GB", None)
   private val goodsDetails = GoodsDetails("name", "description", None, None, None)
   private val submissionReference = "submissionReference"
   private val method = MethodOne(None, None, None)

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/AuditServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/AuditServiceSpec.scala
@@ -51,7 +51,7 @@ class AuditServiceSpec extends AnyFreeSpec with Matchers with MockitoSugar with 
 
   private val hc: HeaderCarrier = HeaderCarrier()
 
-  private val trader = TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None)
+  private val trader = TraderDetail("eori", true, "name", "line1", None, None, "postcode", "GB", None)
   private val goodsDetails = GoodsDetails("name", "description", None, None, None)
   private val method = MethodOne(None, None, None)
   private val contact = ContactDetails("name", "email", None)

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/DmsSubmissionServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/DmsSubmissionServiceSpec.scala
@@ -65,7 +65,7 @@ class DmsSubmissionServiceSpec extends AnyFreeSpec with Matchers with ScalaFutur
 
   "submitApplication" - {
 
-    val trader = TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None)
+    val trader = TraderDetail("eori", true, "name", "line1", None, None, "postcode", "GB", None)
     val goodsDetails = GoodsDetails("name", "description", None, None, None)
     val method = MethodOne(None, None, None)
     val contact = ContactDetails("name", "email", None)

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/FopServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/FopServiceSpec.scala
@@ -50,6 +50,7 @@ class FopServiceSpec extends AnyFreeSpec with Matchers with ScalaFutures with In
         applicantEori = "GB905360708861",
         trader = TraderDetail(
           eori = "GB905360708861",
+          consentToDisclosureOfPersonalData = true,
           businessName = "Some business",
           addressLine1 = "1 The Street",
           addressLine2 = Some("Some town"),
@@ -60,6 +61,7 @@ class FopServiceSpec extends AnyFreeSpec with Matchers with ScalaFutures with In
         ),
         agent = Some(TraderDetail(
           eori = "GB123123456456",
+          consentToDisclosureOfPersonalData = true,
           businessName = "Some other business",
           addressLine1 = "2 The Street",
           addressLine2 = Some("Some town"),


### PR DESCRIPTION
This adds the `consentToDisclosureOfPersonalData` to the `TraderDetails` so it can be used to hide personal details on the ViewApplication page on the frontend.