### PR TITLE
ARS-900: attachments on pdf with confidentiality

### DIFF
--- a/app/uk/gov/hmrc/advancevaluationrulings/views/AttachmentLine.scala.xml
+++ b/app/uk/gov/hmrc/advancevaluationrulings/views/AttachmentLine.scala.xml
@@ -7,12 +7,11 @@
 <fo:block border-bottom-width="1pt" border-bottom-style="solid" margin-top="1mm" margin-bottom="1mm"
           border-bottom-color="gray" padding-top="1mm" padding-bottom="1mm">
 
-    <fo:inline-container width="5cm">
-        <fo:block font-weight="bold">@messages(key)</fo:block>
+    <fo:inline-container width="4cm" text-align="top">
+        <fo:block font-weight="bold" text-align="top">@messages(key)</fo:block>
     </fo:inline-container>
 
-    <fo:inline-container width="12cm" margin-left="1cm">
-        <fo:block>
+    <fo:inline-container alignment-baseline="after-edge" width="12cm" margin-left="1cm">
             <fo:table>
                 <fo:table-body>
 
@@ -40,7 +39,6 @@
 
                 </fo:table-body>
             </fo:table>
-        </fo:block>
     </fo:inline-container>
 
 </fo:block>

--- a/app/uk/gov/hmrc/advancevaluationrulings/views/AttachmentLine.scala.xml
+++ b/app/uk/gov/hmrc/advancevaluationrulings/views/AttachmentLine.scala.xml
@@ -1,0 +1,47 @@
+@import uk.gov.hmrc.advancevaluationrulings.models.application._
+
+        @this()
+
+        @(key: String, attachments: Seq[Attachment])(implicit messages: Messages)
+
+<fo:block border-bottom-width="1pt" border-bottom-style="solid" margin-top="1mm" margin-bottom="1mm"
+          border-bottom-color="gray" padding-top="1mm" padding-bottom="1mm">
+
+    <fo:inline-container width="5cm">
+        <fo:block font-weight="bold">@messages(key)</fo:block>
+    </fo:inline-container>
+
+    <fo:inline-container width="12cm" margin-left="1cm">
+        <fo:block>
+            <fo:table>
+                <fo:table-body>
+
+                    <fo:table-row>
+                        <fo:table-cell width="6cm">
+                            <fo:block font-weight="bold">File name</fo:block>
+                            <!-- en: First Cell -->
+                        </fo:table-cell>
+                        <fo:table-cell width="6cm">
+                            <fo:block font-weight="bold">Confidentiality</fo:block>
+                            <!-- Second Cell -->
+                        </fo:table-cell>
+                    </fo:table-row>
+
+                    @attachments.map { att =>
+                    <fo:table-row>
+                        <fo:table-cell width="6cm">
+                            <fo:block wrap-option="wrap" keep-together="auto">@(att.name)</fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell width="6cm">
+                            <fo:block wrap-option="wrap" keep-together="auto">@(att.privacy)</fo:block>
+                        </fo:table-cell>
+                    </fo:table-row>
+                    }
+
+                </fo:table-body>
+            </fo:table>
+        </fo:block>
+    </fo:inline-container>
+
+</fo:block>
+

--- a/app/uk/gov/hmrc/advancevaluationrulings/views/GoodsDetails.scala.xml
+++ b/app/uk/gov/hmrc/advancevaluationrulings/views/GoodsDetails.scala.xml
@@ -9,7 +9,8 @@
     methodFourSnippet: MethodFourSnippet,
     methodFiveSnippet: MethodFiveSnippet,
     methodSixSnippet: MethodSixSnippet,
-    line: Line
+    line: Line,
+    attachmentLine: AttachmentLine
 )
 
 @(application: Application)(implicit messages: Messages)
@@ -71,6 +72,7 @@
             }.getOrElse {
                 @line(messages("pdf.confidentialInformation"), messages("pdf.no"))
             }
+            @attachmentLine("pdf.attachments", application.attachments)
 
             <fo:block id="FinalElement">
 

--- a/conf/messages
+++ b/conf/messages
@@ -65,3 +65,4 @@ pdf.knownLegalProceedings = Have the goods been subject to any legal challenges?
 pdf.knownLegalProceedingsDescription = Description of legal challenges
 pdf.confidentialInformation = Do you want to add any confidential information about the goods?
 pdf.confidentialInformationDescription = Description of confidential information
+pdf.attachments = Uploaded files

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/FopServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/FopServiceSpec.scala
@@ -18,26 +18,53 @@ package uk.gov.hmrc.advancevaluationrulings.services
 
 import java.nio.file.{Files, Paths}
 import java.time.Instant
+
 import scala.io.Source
+
 import play.api.i18n.MessagesApi
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 import uk.gov.hmrc.advancevaluationrulings.models.application._
+import uk.gov.hmrc.advancevaluationrulings.models.application.Privacy.{Confidential, Public}
 import uk.gov.hmrc.advancevaluationrulings.views.xml.ApplicationPdf
+
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import uk.gov.hmrc.advancevaluationrulings.models.application.Privacy.{Confidential, Public}
 
 class FopServiceSpec extends AnyFreeSpec with Matchers with ScalaFutures with IntegrationPatience {
 
-  private val app = GuiceApplicationBuilder().build()
+  private val app        = GuiceApplicationBuilder().build()
   private val fopService = app.injector.instanceOf[FopService]
-  val attmts = Seq(
-    Attachment(12345, "SomeFile1", Some("description of file"), "someLocation", Confidential, "pdf", 12345),
-    Attachment(12345, "SomeFile2", Some("description of file"), "someLocation", Public, "pdf", 12345),
-    Attachment(12345, "SomeFile3", Some("description of file"), "someLocation", Confidential, "pdf", 12345)
+  val attmts             = Seq(
+    Attachment(
+      12345,
+      "SomeFile1",
+      Some("description of file"),
+      "someLocation",
+      Confidential,
+      "pdf",
+      12345
+    ),
+    Attachment(
+      12345,
+      "SomeFile2",
+      Some("description of file"),
+      "someLocation",
+      Public,
+      "pdf",
+      12345
+    ),
+    Attachment(
+      12345,
+      "SomeFile3",
+      Some("description of file"),
+      "someLocation",
+      Confidential,
+      "pdf",
+      12345
+    )
   )
 
   "render" - {
@@ -109,7 +136,7 @@ class FopServiceSpec extends AnyFreeSpec with Matchers with ScalaFutures with In
       val view      = app.injector.instanceOf[ApplicationPdf]
       val messages  = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
       val xmlString = view.render(application, messages).body
-      val result = fopService.render(xmlString).futureValue
+      val result    = fopService.render(xmlString).futureValue
 
       val fileName = "test/resources/fop/test.pdf"
       Files.write(Paths.get(fileName), result)

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/FopServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/FopServiceSpec.scala
@@ -18,24 +18,27 @@ package uk.gov.hmrc.advancevaluationrulings.services
 
 import java.nio.file.{Files, Paths}
 import java.time.Instant
-
 import scala.io.Source
-
 import play.api.i18n.MessagesApi
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 import uk.gov.hmrc.advancevaluationrulings.models.application._
 import uk.gov.hmrc.advancevaluationrulings.views.xml.ApplicationPdf
-
 import org.apache.pdfbox.pdmodel.PDDocument
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
+import uk.gov.hmrc.advancevaluationrulings.models.application.Privacy.{Confidential, Public}
 
 class FopServiceSpec extends AnyFreeSpec with Matchers with ScalaFutures with IntegrationPatience {
 
-  private val app        = GuiceApplicationBuilder().build()
+  private val app = GuiceApplicationBuilder().build()
   private val fopService = app.injector.instanceOf[FopService]
+  val attmts = Seq(
+    Attachment(12345, "SomeFile1", Some("description of file"), "someLocation", Confidential, "pdf", 12345),
+    Attachment(12345, "SomeFile2", Some("description of file"), "someLocation", Public, "pdf", 12345),
+    Attachment(12345, "SomeFile3", Some("description of file"), "someLocation", Confidential, "pdf", 12345)
+  )
 
   "render" - {
 
@@ -97,7 +100,7 @@ class FopServiceSpec extends AnyFreeSpec with Matchers with ScalaFutures with In
           ),
           confidentialInformation = Some("Some confidential information")
         ),
-        attachments = Nil,
+        attachments = attmts,
         submissionReference = "submissionReference",
         created = Instant.now,
         lastUpdated = Instant.now
@@ -106,7 +109,7 @@ class FopServiceSpec extends AnyFreeSpec with Matchers with ScalaFutures with In
       val view      = app.injector.instanceOf[ApplicationPdf]
       val messages  = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
       val xmlString = view.render(application, messages).body
-      val result    = fopService.render(xmlString).futureValue
+      val result = fopService.render(xmlString).futureValue
 
       val fileName = "test/resources/fop/test.pdf"
       Files.write(Paths.get(fileName), result)


### PR DESCRIPTION
- table added to output pdf with filename and privacy

![image](https://github.com/hmrc/advance-valuation-rulings/assets/77161245/273d3194-eed2-4e40-a470-f5f70443bb97)

