### PR TITLE
ARS-963: Update MongoVersion to 1.2.0 (Backend)

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,7 @@ object AppDependencies {
 
   private val AllTestScope     = "test, it"
   private val bootstrapVersion = "7.15.0"
-  private val hmrcMongoVersion = "1.1.0"
+  private val hmrcMongoVersion = "1.2.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"             %% "bootstrap-backend-play-28"    % bootstrapVersion,


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [ x] Non-breaking change
- [ ] Cosmetic change

### Description
https://jira.tools.tax.service.gov.uk/browse/ARS-963
update hmrcMongoVersion to 1.2.0 where timeout is 5 seconds
