### PR TITLE
ARSSTB-402 Enabled accessibility in the FOP library

### DIFF
--- a/app/uk/gov/hmrc/advancevaluationrulings/services/FopService.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/services/FopService.scala
@@ -38,7 +38,11 @@ class FopService @Inject() (
 
     Using.resource(new ByteArrayOutputStream()) {
       out =>
-        val fop = fopFactory.newFop(MimeConstants.MIME_PDF, out)
+        // Turn on accessibility features
+        val userAgent = fopFactory.newFOUserAgent();
+        userAgent.setAccessibility(true);
+
+        val fop = fopFactory.newFop(MimeConstants.MIME_PDF, userAgent, out)
 
         val transformerFactory = TransformerFactory.newInstance()
         val transformer        = transformerFactory.newTransformer()


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [x] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [Accessibility fix needed for PDF being sent to caseworkers](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-402)

Added a setting to enable accessibility in the FOP library. With this new setting on, the application pdf sent to the caseworkers will have certain new features that help screen readers navigate the document. The layout and contents of the pdf won't change.
