### PR TITLE
removed eori number from applicant info for agentfortrader role

### DIFF
--- a/app/uk/gov/hmrc/advancevaluationrulings/views/ApplicationSummary.scala.xml
+++ b/app/uk/gov/hmrc/advancevaluationrulings/views/ApplicationSummary.scala.xml
@@ -30,7 +30,12 @@
                 @messages("pdf.applicationSummary")
             </fo:block>
 
-            @line(roleHelper.messagesForAgentTraderOrOtherRole(application, messages("pdf.agentTraderEori"), messages("pdf.traderEori")), application.trader.eori)
+            @application.whatIsYourRoleResponse.map { role =>
+                @if(role != WhatIsYourRole.AgentTrader) {
+                    @line(messages("pdf.traderEori"), application.trader.eori)
+                }
+            }
+
 
             @line(messages("pdf.applicationId"), application.id.toString)
 


### PR DESCRIPTION
### Type of change
- [X] Breaking change
- [ ] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [PDF to DMS/caseworkers - Agent for trader should be split in agent and applicant details section](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-515)

This is to fix the EORI number showing up twice in the PDF