### PR TITLE
Add agent job title to pdf

### DIFF
--- a/app/uk/gov/hmrc/advancevaluationrulings/views/AgentDetail.scala.xml
+++ b/app/uk/gov/hmrc/advancevaluationrulings/views/AgentDetail.scala.xml
@@ -35,4 +35,8 @@
         @line(messages("pdf.agentPhone"), phone)
     }
 
+    @application.contact.jobTitle.map { jobTitle =>
+        @line(messages("pdf.agentJobTitle"), jobTitle)
+    }
+
 </fo:block-container>

--- a/app/uk/gov/hmrc/advancevaluationrulings/views/AgentInfo.scala.xml
+++ b/app/uk/gov/hmrc/advancevaluationrulings/views/AgentInfo.scala.xml
@@ -32,4 +32,8 @@
         @line(messages("pdf.agentTrader.agentBusinessName"), n)
     }
 
+    @application.contact.jobTitle.map { j =>
+        @line(messages("pdf.agentTrader.agentJobTitle"), j)
+    }
+
 </fo:block-container>

--- a/app/uk/gov/hmrc/advancevaluationrulings/views/TraderDetail.scala.xml
+++ b/app/uk/gov/hmrc/advancevaluationrulings/views/TraderDetail.scala.xml
@@ -39,6 +39,10 @@
         @application.contact.companyName.map { companyName =>
             @line(roleHelper.messagesForAgentTraderOrOtherRole(application,messages("pdf.agentTrader.agentBusinessName"), messages("pdf.agent.businessName")), companyName)
         }
+
+        @application.contact.jobTitle.map { jobTitle =>
+            @line(roleHelper.messagesForAgentTraderOrOtherRole(application,messages("pdf.agentTrader.agentJobTitle"), messages("pdf.agent.jobTitle")), jobTitle)
+        }
     }
 
     @application.whatIsYourRoleResponse.map { role =>

--- a/conf/messages
+++ b/conf/messages
@@ -30,6 +30,7 @@ pdf.agentTrader.email = Agent’s email address
 pdf.agentTrader.traderBusinessName = Trader’s registered business name
 pdf.agentTrader.agentBusinessName = Agent’s company name
 pdf.agentTrader.address = Trader’s registered business address
+pdf.agentTrader.agentJobTitle = Agent’s job title
 
 pdf.agentDetail = About the agent
 pdf.agent.eori = Agent EORI number
@@ -39,6 +40,7 @@ pdf.agent.address = Agent business address
 pdf.agentName = Agent name
 pdf.agentEmail = Agent email address
 pdf.agentPhone = Agent telephone number
+pdf.agentJobTitle = Agent job title
 
 pdf.goodsDetails = About the goods
 pdf.method = Proposed method of valuation


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [x] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [User tell HMRC what their role is within the company](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-314)

Add the agent job title to the generated PDFs.

### Attachments or Screenshots
These screenshots give a rough idea of what the PDFs will look like: I created them by modifying FopServiceSpec, running these tests and opening the PDF generated in test/resources/fop/test.pdf.

Employee:
![Employee PDF](https://github.com/hmrc/advance-valuation-rulings/assets/132440545/561d1faa-fc30-473e-9ef7-e94b0fca185d)

Agent Org:
![Agent Org PDF](https://github.com/hmrc/advance-valuation-rulings/assets/132440545/25a0df27-1131-4695-9b8a-bf6b1697dd50)

Agent Trader:
![Agent Trader PDF](https://github.com/hmrc/advance-valuation-rulings/assets/132440545/5e0b211e-413b-403a-a3ff-9fdb8ebbd981)
