### PR TITLE
fix: ensure Employee role label displays in the pdf

### DIFF
--- a/app/uk/gov/hmrc/advancevaluationrulings/views/TraderDetail.scala.xml
+++ b/app/uk/gov/hmrc/advancevaluationrulings/views/TraderDetail.scala.xml
@@ -41,7 +41,7 @@
         }
 
         @application.contact.jobTitle.map { jobTitle =>
-            @line(roleHelper.messagesForAgentTraderOrOtherRole(application,messages("pdf.agentTrader.agentJobTitle"), messages("pdf.agent.jobTitle")), jobTitle)
+            @line(roleHelper.messagesForAgentTraderOrOtherRole(application,messages("pdf.agentTrader.agentJobTitle"), messages("pdf.applicantJobTitle")), jobTitle)
         }
     }
 

--- a/conf/messages
+++ b/conf/messages
@@ -24,6 +24,7 @@ pdf.agentTrader.name = Agent’s full name
 pdf.applicantEmail = Applicant email address
 pdf.agentTrader.email = Agent’s email address
 pdf.applicantPhone = Applicant telephone number
+pdf.applicantJobTitle = Applicant job title
 
 pdf.agentTrader.phone = Agent’s telephone number
 pdf.agentTrader.email = Agent’s email address


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [ ] Non-breaking change
- [x] Cosmetic change

### Description
Jira link: [User tell HMRC what their role is within the company](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-314)

Ensure Employee role label displays in the PDF, rather than the key name.

### Attachments or Screenshots

![Employee PDF](https://github.com/hmrc/advance-valuation-rulings/assets/132440545/75952027-9f1c-4446-8eb5-9ea59c8d8109)
