### PR TITLE
ARSSTB-538 added ttl index for applications for 366 days (1 year)

### DIFF
--- a/app/uk/gov/hmrc/advancevaluationrulings/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/config/AppConfig.scala
@@ -39,4 +39,5 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
       .getConfString(confKey, throw new RuntimeException(s"Could not find config key '$confKey'"))
 
   val userAnswersTtlInDays: Int = config.get[Int]("mongodb.userAnswersTtlInDays")
+  val applicationTtlInDays: Int = config.get[Int]("mongodb.applicationTtlInDays")
 }

--- a/app/uk/gov/hmrc/advancevaluationrulings/repositories/ApplicationRepository.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/repositories/ApplicationRepository.scala
@@ -43,7 +43,7 @@ class ApplicationRepository @Inject() (
         IndexModel(
           Indexes.ascending("lastUpdated"),
           IndexOptions()
-            .name("last-updated-index")
+            .name("last-updated-index-applications")
             .expireAfter(appConfig.applicationTtlInDays, TimeUnit.DAYS)
         ),
         IndexModel(

--- a/app/uk/gov/hmrc/advancevaluationrulings/repositories/ApplicationRepository.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/repositories/ApplicationRepository.scala
@@ -16,10 +16,12 @@
 
 package uk.gov.hmrc.advancevaluationrulings.repositories
 
+import java.util.concurrent.TimeUnit
 import javax.inject.{Inject, Singleton}
 
 import scala.concurrent.{ExecutionContext, Future}
 
+import uk.gov.hmrc.advancevaluationrulings.config.AppConfig
 import uk.gov.hmrc.advancevaluationrulings.models.Done
 import uk.gov.hmrc.advancevaluationrulings.models.application.{Application, ApplicationId, ApplicationSummary}
 import uk.gov.hmrc.mongo.MongoComponent
@@ -30,13 +32,20 @@ import org.mongodb.scala.model._
 
 @Singleton
 class ApplicationRepository @Inject() (
-  mongoComponent: MongoComponent
+  mongoComponent: MongoComponent,
+  appConfig: AppConfig
 )(implicit ec: ExecutionContext)
     extends PlayMongoRepository[Application](
       collectionName = "applications",
       mongoComponent = mongoComponent,
       domainFormat = Application.format(MongoJavatimeFormats.instantFormat),
       indexes = Seq(
+        IndexModel(
+          Indexes.ascending("lastUpdated"),
+          IndexOptions()
+            .name("last-updated-index")
+            .expireAfter(appConfig.applicationTtlInDays, TimeUnit.DAYS)
+        ),
         IndexModel(
           Indexes.ascending("id"),
           IndexOptions()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -68,6 +68,7 @@ controllers {
 mongodb {
   uri = "mongodb://localhost:27017/advance-valuation-rulings"
   userAnswersTtlInDays = 28
+  applicationTtlInDays = 366
 }
 
 microservice {

--- a/it/uk/gov/hmrc/advancevaluationrulings/repositories/ApplicationRepositorySpec.scala
+++ b/it/uk/gov/hmrc/advancevaluationrulings/repositories/ApplicationRepositorySpec.scala
@@ -5,9 +5,11 @@ import java.time.temporal.ChronoUnit
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
+import uk.gov.hmrc.advancevaluationrulings.config.AppConfig
 import uk.gov.hmrc.advancevaluationrulings.models.application._
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 
+import org.mockito.MockitoSugar.{mock, when}
 import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
@@ -20,7 +22,10 @@ class ApplicationRepositorySpec
     with OptionValues
     with ScalaFutures {
 
-  protected override val repository = new ApplicationRepository(mongoComponent)
+  private val mockAppConfig = mock[AppConfig]
+  when(mockAppConfig.applicationTtlInDays) thenReturn 1
+
+  protected override val repository = new ApplicationRepository(mongoComponent, mockAppConfig)
 
   private val trader              =
     TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None, Some(true))


### PR DESCRIPTION
### Type of change
- [ ] Breaking change
- [X] Non-breaking change
- [ ] Cosmetic change

### Description
Jira link: [Add data retention period to our back end Mongo DB](https://jira.tools.tax.service.gov.uk/browse/ARSSTB-538)

Added TTL index of 366 days to last-updated field of applications
