### PR TITLE
make change to application id by linking it to the draft

### DIFF
--- a/app/uk/gov/hmrc/advancevaluationrulings/models/DraftId.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/models/DraftId.scala
@@ -17,18 +17,21 @@
 package uk.gov.hmrc.advancevaluationrulings.models
 
 import scala.util.Try
-
 import play.api.libs.json._
 import play.api.mvc.PathBindable
+import uk.gov.hmrc.advancevaluationrulings.models.application.ApplicationId
 
 final case class DraftId(value: Long) {
   override val toString: String = s"DRAFT%09d".format(value)
+
+  def toApplicationId(): Try[ApplicationId] = ApplicationId(value.toString)
 }
 
 object DraftId {
 
   def apply(valueString: String): Try[DraftId] =
     Try(DraftId(valueString.toInt))
+
 
   def fromString(string: String): Option[DraftId] = {
 

--- a/app/uk/gov/hmrc/advancevaluationrulings/models/application/ApplicationId.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/models/application/ApplicationId.scala
@@ -38,7 +38,6 @@ object ApplicationId {
     string match {
       case pattern(value) =>
         ApplicationId(value).toOption
-
       case _ =>
         None
     }

--- a/app/uk/gov/hmrc/advancevaluationrulings/services/ApplicationService.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/services/ApplicationService.scala
@@ -45,7 +45,8 @@ class ApplicationService @Inject() (
     hc: HeaderCarrier
   ): Future[ApplicationId] =
     for {
-      appId              <- counterRepository.nextId(CounterId.ApplicationId).map(ApplicationId(_))
+//      appId              <- counterRepository.nextId(CounterId.ApplicationId).map(ApplicationId(_))
+      appId <- Future.fromTry(request.draftId.toApplicationId())
       attachments        <- buildAttachments(appId, request.attachments)
       submissionReference = submissionReferenceService.random()
       letterOfAuthority  <- buildLetterOfAuthority(appId, request.letterOfAuthority)


### PR DESCRIPTION
There is an issue with the application id where it is using a counter repo in mongo to help create the application Id. This combined with the application being created all at a single point, that being the CheckYourAnswersPage submit button means it is difficult to compare in mongo for the newly generated application Id for an application Id that exists prior. 

If we link the draft Id to the application Id then it should in my mind still be unique and not duplicate. The issue is how we link the two together and is there a need to mask the application Id ties to it's draft id? 