### PR TITLE
DDCE-4895: Ensure mongo is not used in unit tests

### DIFF
--- a/it/uk/gov/hmrc/advancevaluationrulings/repositories/ApplicationRepositorySpec.scala
+++ b/it/uk/gov/hmrc/advancevaluationrulings/repositories/ApplicationRepositorySpec.scala
@@ -23,7 +23,8 @@ class ApplicationRepositorySpec
   private val mockAppConfig = mock[AppConfig]
   when(mockAppConfig.applicationTtlInDays) thenReturn 1
 
-  protected override val repository = new ApplicationRepository(mongoComponent, mockAppConfig)
+  protected override val repository: ApplicationMongoRepository =
+    new ApplicationMongoRepository(mongoComponent, mockAppConfig)
 
   private val trader              =
     TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None, Some(true))

--- a/it/uk/gov/hmrc/advancevaluationrulings/repositories/CounterRepositorySpec.scala
+++ b/it/uk/gov/hmrc/advancevaluationrulings/repositories/CounterRepositorySpec.scala
@@ -18,7 +18,7 @@ class CounterRepositorySpec
     with ScalaFutures
     with BeforeAndAfterEach {
 
-  protected override val repository = new CounterRepository(mongoComponent)
+  protected override val repository = new CounterMongoRepository(mongoComponent)
 
   override def beforeEach(): Unit = {
     super.beforeEach()

--- a/it/uk/gov/hmrc/advancevaluationrulings/repositories/UserAnswersRepositorySpec.scala
+++ b/it/uk/gov/hmrc/advancevaluationrulings/repositories/UserAnswersRepositorySpec.scala
@@ -1,20 +1,5 @@
 package uk.gov.hmrc.advancevaluationrulings.repositories
 
-import java.security.SecureRandom
-import java.time.{Clock, Instant, ZoneId}
-import java.time.temporal.ChronoUnit
-import java.util.Base64
-
-import scala.concurrent.ExecutionContext.Implicits.global
-
-import play.api.Configuration
-import play.api.libs.json.Json
-import uk.gov.hmrc.advancevaluationrulings.config.AppConfig
-import uk.gov.hmrc.advancevaluationrulings.models.{Done, DraftId, UserAnswers}
-import uk.gov.hmrc.advancevaluationrulings.models.application.DraftSummary
-import uk.gov.hmrc.crypto.{Decrypter, Encrypter, SymmetricCryptoFactory}
-import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
-
 import com.fasterxml.jackson.core.JsonParseException
 import org.mockito.MockitoSugar
 import org.mongodb.scala.bson.BsonDocument
@@ -23,6 +8,19 @@ import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
+import play.api.Configuration
+import play.api.libs.json.Json
+import uk.gov.hmrc.advancevaluationrulings.config.AppConfig
+import uk.gov.hmrc.advancevaluationrulings.models.application.DraftSummary
+import uk.gov.hmrc.advancevaluationrulings.models.{Done, DraftId, UserAnswers}
+import uk.gov.hmrc.crypto.{Decrypter, Encrypter, SymmetricCryptoFactory}
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+
+import java.security.SecureRandom
+import java.time.temporal.ChronoUnit
+import java.time.{Clock, Instant, ZoneId}
+import java.util.Base64
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class UserAnswersRepositorySpec
     extends AnyFreeSpec
@@ -52,7 +50,7 @@ class UserAnswersRepositorySpec
   private implicit val crypto: Encrypter with Decrypter =
     SymmetricCryptoFactory.aesGcmCryptoFromConfig("crypto", configuration.underlying)
 
-  protected override val repository = new UserAnswersRepository(
+  protected override val repository: UserAnswersMongoRepository = new UserAnswersMongoRepository(
     mongoComponent = mongoComponent,
     appConfig = mockAppConfig,
     clock = stubClock

--- a/it/uk/gov/hmrc/advancevaluationrulings/repositories/UserAnswersRepositorySpec.scala
+++ b/it/uk/gov/hmrc/advancevaluationrulings/repositories/UserAnswersRepositorySpec.scala
@@ -76,7 +76,7 @@ class UserAnswersRepositorySpec
 
     "must store the data section as encrypted bytes" in {
 
-      repository.set(answers).futureValue
+      repository.set(answers).futureValue mustBe Done
 
       val record = repository.collection
         .find[BsonDocument](
@@ -104,7 +104,7 @@ class UserAnswersRepositorySpec
 
       "must update the lastUpdated time and get the record" in {
 
-        insert(answers).futureValue
+        insert(answers).futureValue.wasAcknowledged() mustBe true
 
         val result         = repository.get(answers.userId, answers.draftId).futureValue
         val expectedResult = answers copy (lastUpdated = instant)
@@ -119,7 +119,7 @@ class UserAnswersRepositorySpec
 
         val differentAnswers = answers.copy(draftId = DraftId(2))
 
-        insert(differentAnswers).futureValue
+        insert(differentAnswers).futureValue.wasAcknowledged() mustBe true
 
         repository.get("userId", DraftId(1)).futureValue must not be defined
       }
@@ -131,7 +131,7 @@ class UserAnswersRepositorySpec
 
         val differentAnswers = answers.copy(userId = "another user id")
 
-        insert(differentAnswers).futureValue
+        insert(differentAnswers).futureValue.wasAcknowledged() mustBe true
 
         repository.get("userId", DraftId(1)).futureValue must not be defined
       }
@@ -152,7 +152,7 @@ class UserAnswersRepositorySpec
 
       "must get the record" in {
 
-        insert(answers).futureValue
+        insert(answers).futureValue.wasAcknowledged() mustBe true
 
         val result = repository.get(answers.draftId).futureValue
 
@@ -173,7 +173,7 @@ class UserAnswersRepositorySpec
 
     "must remove a record" in {
 
-      insert(answers).futureValue
+      insert(answers).futureValue.wasAcknowledged() mustBe true
 
       val result = repository.clear(answers.userId, answers.draftId).futureValue
 
@@ -183,7 +183,7 @@ class UserAnswersRepositorySpec
 
     "must return Done when there is no record to remove" in {
 
-      repository.clear("user id that does not exist", DraftId(2)).futureValue
+      repository.clear("user id that does not exist", DraftId(2)).futureValue mustEqual Done
     }
   }
 
@@ -193,9 +193,9 @@ class UserAnswersRepositorySpec
 
       "must update its lastUpdated to `now`" in {
 
-        insert(answers).futureValue
+        insert(answers).futureValue.wasAcknowledged() mustBe true
 
-        repository.keepAlive(answers.userId, answers.draftId).futureValue
+        repository.keepAlive(answers.userId, answers.draftId).futureValue mustBe Done
 
         val expectedUpdatedAnswers = answers copy (lastUpdated = instant)
 
@@ -213,7 +213,7 @@ class UserAnswersRepositorySpec
 
       "must succeed" in {
 
-        repository.keepAlive("user id that does not exist", DraftId(2)).futureValue
+        repository.keepAlive("user id that does not exist", DraftId(2)).futureValue mustEqual Done
       }
     }
   }
@@ -225,9 +225,9 @@ class UserAnswersRepositorySpec
       val answers2 = answers.copy(draftId = DraftId(2))
       val answers3 = answers.copy(userId = "other user id", draftId = DraftId(3))
 
-      insert(answers).futureValue
-      insert(answers2).futureValue
-      insert(answers3).futureValue
+      insert(answers).futureValue.wasAcknowledged() mustBe true
+      insert(answers2).futureValue.wasAcknowledged() mustBe true
+      insert(answers3).futureValue.wasAcknowledged() mustBe true
 
       val result = repository.summaries("userId").futureValue
 

--- a/test/resources/application.conf
+++ b/test/resources/application.conf
@@ -1,0 +1,15 @@
+# Copyright 2023 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+play.modules.disabled += "uk.gov.hmrc.mongo.play.PlayMongoModule"

--- a/test/uk/gov/hmrc/advancevaluationrulings/base/SpecBase.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/base/SpecBase.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.advancevaluationrulings.base
+
+import org.mockito.MockitoSugar.mock
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.must.Matchers
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import uk.gov.hmrc.advancevaluationrulings.repositories.{ApplicationRepository, CounterRepository, UserAnswersRepository}
+
+trait SpecBase extends Matchers with OptionValues with ScalaFutures {
+  val mockApplicationRepository: ApplicationRepository = mock[ApplicationRepository]
+  val mockCounterRepository: CounterRepository = mock[CounterRepository]
+  val mockUserAnswersRepository: UserAnswersRepository = mock[UserAnswersRepository]
+
+  def applicationBuilder: GuiceApplicationBuilder = new GuiceApplicationBuilder()
+    .overrides(
+      bind[ApplicationRepository].to(mockApplicationRepository),
+      bind[CounterRepository].to(mockCounterRepository),
+      bind[UserAnswersRepository].to(mockUserAnswersRepository)
+    )
+
+}

--- a/test/uk/gov/hmrc/advancevaluationrulings/base/SpecBase.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/base/SpecBase.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.advancevaluationrulings.repositories.{ApplicationRepository, 
 
 trait SpecBase extends Matchers with OptionValues with ScalaFutures {
   val mockApplicationRepository: ApplicationRepository = mock[ApplicationRepository]
-  val mockCounterRepository: CounterRepository = mock[CounterRepository]
+  val mockCounterRepository: CounterRepository         = mock[CounterRepository]
   val mockUserAnswersRepository: UserAnswersRepository = mock[UserAnswersRepository]
 
   def applicationBuilder: GuiceApplicationBuilder = new GuiceApplicationBuilder()

--- a/test/uk/gov/hmrc/advancevaluationrulings/controllers/ApplicationControllerSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/controllers/ApplicationControllerSpec.scala
@@ -20,18 +20,17 @@ import generators.ModelGenerators
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchersSugar.eqTo
 import org.mockito.MockitoSugar
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.{BeforeAndAfterEach, OptionValues}
+import play.api
 import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import uk.gov.hmrc.advancevaluationrulings.base.SpecBase
 import uk.gov.hmrc.advancevaluationrulings.models.DraftId
 import uk.gov.hmrc.advancevaluationrulings.models.application._
 import uk.gov.hmrc.advancevaluationrulings.models.audit.AuditMetadata
-import uk.gov.hmrc.advancevaluationrulings.repositories.ApplicationRepository
 import uk.gov.hmrc.advancevaluationrulings.services.ApplicationService
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.~
@@ -41,16 +40,14 @@ import scala.concurrent.Future
 
 class ApplicationControllerSpec
     extends AnyFreeSpec
-    with Matchers
-    with OptionValues
+    with SpecBase
     with ModelGenerators
     with MockitoSugar
     with BeforeAndAfterEach {
 
-  private val fixedClock                = Clock.fixed(Instant.now, ZoneId.systemDefault)
-  private val mockApplicationService    = mock[ApplicationService]
-  private val mockApplicationRepository = mock[ApplicationRepository]
-  private val mockAuthConnector         = mock[AuthConnector]
+  private val fixedClock             = Clock.fixed(Instant.now, ZoneId.systemDefault)
+  private val mockApplicationService = mock[ApplicationService]
+  private val mockAuthConnector      = mock[AuthConnector]
 
   private val applicantEori       = "applicantEori"
   private val atarEnrolment       = Enrolments(
@@ -65,12 +62,11 @@ class ApplicationControllerSpec
   private val method              = MethodOne(None, None, None)
   private val contact             = ContactDetails("name", "email", None, None, None)
 
-  private val app =
-    GuiceApplicationBuilder()
+  private val app: api.Application =
+    applicationBuilder
       .overrides(
         bind[Clock].toInstance(fixedClock),
         bind[ApplicationService].toInstance(mockApplicationService),
-        bind[ApplicationRepository].toInstance(mockApplicationRepository),
         bind[AuthConnector].toInstance(mockAuthConnector)
       )
       .build()

--- a/test/uk/gov/hmrc/advancevaluationrulings/controllers/DmsSubmissionCallbackControllerSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/controllers/DmsSubmissionCallbackControllerSpec.scala
@@ -18,29 +18,21 @@ package uk.gov.hmrc.advancevaluationrulings.controllers
 
 import org.mockito.ArgumentMatchers.any
 import org.mockito.MockitoSugar
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.{BeforeAndAfterEach, OptionValues}
 import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import uk.gov.hmrc.advancevaluationrulings.base.SpecBase
 import uk.gov.hmrc.advancevaluationrulings.models.dms.{NotificationRequest, SubmissionItemStatus}
-import uk.gov.hmrc.internalauth.client.test.{BackendAuthComponentsStub, StubBehaviour}
 import uk.gov.hmrc.internalauth.client._
+import uk.gov.hmrc.internalauth.client.test.{BackendAuthComponentsStub, StubBehaviour}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class DmsSubmissionCallbackControllerSpec
-    extends AnyFreeSpec
-    with Matchers
-    with OptionValues
-    with ScalaFutures
-    with MockitoSugar
-    with BeforeAndAfterEach {
+class DmsSubmissionCallbackControllerSpec extends AnyFreeSpec with SpecBase with MockitoSugar with BeforeAndAfterEach {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -51,7 +43,7 @@ class DmsSubmissionCallbackControllerSpec
   private val stubBackendAuthComponents =
     BackendAuthComponentsStub(mockStubBehaviour)(stubControllerComponents(), implicitly)
 
-  private val app = GuiceApplicationBuilder()
+  private val app = applicationBuilder
     .overrides(
       bind[BackendAuthComponents].toInstance(stubBackendAuthComponents)
     )

--- a/test/uk/gov/hmrc/advancevaluationrulings/controllers/TraderDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/controllers/TraderDetailsControllerSpec.scala
@@ -20,26 +20,25 @@ import generators.ModelGenerators
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchersSugar.eqTo
 import org.mockito.MockitoSugar
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.{BeforeAndAfterEach, OptionValues}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.Application
 import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import uk.gov.hmrc.advancevaluationrulings.base.SpecBase
 import uk.gov.hmrc.advancevaluationrulings.models.common.{AcknowledgementReference, EoriNumber}
 import uk.gov.hmrc.advancevaluationrulings.services.TraderDetailsService
-import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve.~
 
 import scala.concurrent.Future
 
 class TraderDetailsControllerSpec
     extends AnyFreeSpec
-    with Matchers
-    with OptionValues
+    with SpecBase
     with ModelGenerators
     with MockitoSugar
     with BeforeAndAfterEach
@@ -61,8 +60,8 @@ class TraderDetailsControllerSpec
       )
     )
 
-  private val app =
-    GuiceApplicationBuilder()
+  private val app: Application =
+    applicationBuilder
       .overrides(
         bind[AuthConnector].toInstance(mockAuthConnector),
         bind[TraderDetailsService].toInstance(mockTraderDetailsService)

--- a/test/uk/gov/hmrc/advancevaluationrulings/controllers/actions/IdentifierActionSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/controllers/actions/IdentifierActionSpec.scala
@@ -18,22 +18,21 @@ package uk.gov.hmrc.advancevaluationrulings.controllers.actions
 
 import org.mockito.ArgumentMatchers.any
 import org.mockito.MockitoSugar
-import org.scalatest.OptionValues
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.must.Matchers
-import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.Application
 import play.api.libs.json.Json
 import play.api.mvc.Results.Ok
 import play.api.mvc.{Action, AnyContent, BodyParsers}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.auth.core.retrieve.~
+import uk.gov.hmrc.advancevaluationrulings.base.SpecBase
 import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve.~
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class IdentifierActionSpec extends AnyFreeSpec with Matchers with MockitoSugar with OptionValues {
+class IdentifierActionSpec extends AnyFreeSpec with SpecBase with MockitoSugar {
 
   class Harness(identify: IdentifierAction) {
     def onPageLoad(): Action[AnyContent] = identify { request =>
@@ -48,8 +47,8 @@ class IdentifierActionSpec extends AnyFreeSpec with Matchers with MockitoSugar w
     }
   }
 
-  private val app         = new GuiceApplicationBuilder().build()
-  private val bodyParsers = app.injector.instanceOf[BodyParsers.Default]
+  private val app: Application = applicationBuilder.build()
+  private val bodyParsers      = app.injector.instanceOf[BodyParsers.Default]
 
   private val mockAuthConnector: AuthConnector = mock[AuthConnector]
 

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/AttachmentsServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/AttachmentsServiceSpec.scala
@@ -22,13 +22,12 @@ import akka.util.ByteString
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchersSugar.eqTo
 import org.mockito.MockitoSugar
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, OptionValues}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import play.api.Application
 import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
+import uk.gov.hmrc.advancevaluationrulings.base.SpecBase
 import uk.gov.hmrc.advancevaluationrulings.connectors.DraftAttachmentsConnector
 import uk.gov.hmrc.advancevaluationrulings.models.application.{ApplicationId, DraftAttachment}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -44,10 +43,8 @@ import scala.concurrent.Future
 
 class AttachmentsServiceSpec
     extends AnyFreeSpec
-    with Matchers
-    with ScalaFutures
+    with SpecBase
     with IntegrationPatience
-    with OptionValues
     with MockitoSugar
     with BeforeAndAfterEach
     with BeforeAndAfterAll {
@@ -72,7 +69,7 @@ class AttachmentsServiceSpec
 
   private val mockAttachmentsConnector = mock[DraftAttachmentsConnector]
 
-  private lazy val app: Application = GuiceApplicationBuilder()
+  private lazy val app: Application = applicationBuilder
     .overrides(
       bind[PlayObjectStoreClient].toInstance(objectStoreStub),
       bind[DraftAttachmentsConnector].toInstance(mockAttachmentsConnector)

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/AuditServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/AuditServiceSpec.scala
@@ -21,9 +21,9 @@ import org.mockito.ArgumentMatchersSugar.eqTo
 import org.mockito.MockitoSugar
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.must.Matchers
+import play.api
 import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
+import uk.gov.hmrc.advancevaluationrulings.base.SpecBase
 import uk.gov.hmrc.advancevaluationrulings.models.DraftId
 import uk.gov.hmrc.advancevaluationrulings.models.application._
 import uk.gov.hmrc.advancevaluationrulings.models.audit.ApplicationSubmissionEvent
@@ -34,7 +34,7 @@ import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-class AuditServiceSpec extends AnyFreeSpec with Matchers with MockitoSugar with BeforeAndAfterEach {
+class AuditServiceSpec extends AnyFreeSpec with SpecBase with MockitoSugar with BeforeAndAfterEach {
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -43,7 +43,7 @@ class AuditServiceSpec extends AnyFreeSpec with Matchers with MockitoSugar with 
 
   private val mockAuditConnector = mock[AuditConnector]
 
-  private lazy val app = GuiceApplicationBuilder()
+  private lazy val app: api.Application = applicationBuilder
     .overrides(
       bind[AuditConnector].toInstance(mockAuditConnector)
     )

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/DmsSubmissionServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/DmsSubmissionServiceSpec.scala
@@ -21,13 +21,12 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.util.ByteString
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.{ArgumentCaptor, MockitoSugar}
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.{BeforeAndAfterEach, OptionValues}
+import play.api
 import play.api.i18n.{Messages, MessagesApi}
 import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
+import uk.gov.hmrc.advancevaluationrulings.base.SpecBase
 import uk.gov.hmrc.advancevaluationrulings.connectors.DmsSubmissionConnector
 import uk.gov.hmrc.advancevaluationrulings.models.Done
 import uk.gov.hmrc.advancevaluationrulings.models.application._
@@ -38,23 +37,12 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import scala.concurrent.Future
 
-class DmsSubmissionServiceSpec
-    extends AnyFreeSpec
-    with Matchers
-    with ScalaFutures
-    with OptionValues
-    with MockitoSugar
-    with BeforeAndAfterEach {
-
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    reset(mockFopService, mockDmsSubmissionConnector)
-  }
+class DmsSubmissionServiceSpec extends AnyFreeSpec with SpecBase with MockitoSugar with BeforeAndAfterEach {
 
   private val mockFopService             = mock[FopService]
   private val mockDmsSubmissionConnector = mock[DmsSubmissionConnector]
 
-  private lazy val app = GuiceApplicationBuilder()
+  private lazy val app: api.Application = applicationBuilder
     .overrides(
       bind[FopService].toInstance(mockFopService),
       bind[DmsSubmissionConnector].toInstance(mockDmsSubmissionConnector)
@@ -69,6 +57,11 @@ class DmsSubmissionServiceSpec
   private implicit lazy val mat: Materializer  = app.injector.instanceOf[Materializer]
   private implicit lazy val messages: Messages =
     app.injector.instanceOf[MessagesApi].preferred(Seq.empty)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockFopService, mockDmsSubmissionConnector)
+  }
 
   "submitApplication" - {
 

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/FopServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/FopServiceSpec.scala
@@ -17,12 +17,12 @@
 package uk.gov.hmrc.advancevaluationrulings.services
 
 import org.apache.pdfbox.pdmodel.PDDocument
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.must.Matchers
+import play.api
 import play.api.i18n.MessagesApi
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
+import uk.gov.hmrc.advancevaluationrulings.base.SpecBase
 import uk.gov.hmrc.advancevaluationrulings.models.application.Privacy.{Confidential, Public}
 import uk.gov.hmrc.advancevaluationrulings.models.application._
 import uk.gov.hmrc.advancevaluationrulings.views.xml.ApplicationPdf
@@ -31,10 +31,10 @@ import java.nio.file.{Files, Paths}
 import java.time.Instant
 import scala.io.Source
 
-class FopServiceSpec extends AnyFreeSpec with Matchers with ScalaFutures with IntegrationPatience {
+class FopServiceSpec extends AnyFreeSpec with SpecBase with IntegrationPatience {
 
-  private val app        = GuiceApplicationBuilder().build()
-  private val fopService = app.injector.instanceOf[FopService]
+  private val app: api.Application   = applicationBuilder.build()
+  private val fopService: FopService = app.injector.instanceOf[FopService]
 
   private val attmts: Seq[Attachment] = Seq(
     Attachment(

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/TraderDetailsServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/TraderDetailsServiceSpec.scala
@@ -20,13 +20,11 @@ import generators.ModelGenerators
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchersSugar.eqTo
 import org.mockito.MockitoSugar
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.{BeforeAndAfterEach, OptionValues}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import play.api.inject
-import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.{Application, inject}
+import uk.gov.hmrc.advancevaluationrulings.base.SpecBase
 import uk.gov.hmrc.advancevaluationrulings.connectors.ETMPConnector
 import uk.gov.hmrc.advancevaluationrulings.models.common.{AcknowledgementReference, EoriNumber}
 import uk.gov.hmrc.advancevaluationrulings.models.etmp.Regime.CDS
@@ -39,9 +37,7 @@ import scala.concurrent.Future
 
 class TraderDetailsServiceSpec
     extends AnyFreeSpec
-    with Matchers
-    with ScalaFutures
-    with OptionValues
+    with SpecBase
     with MockitoSugar
     with BeforeAndAfterEach
     with ModelGenerators
@@ -57,7 +53,7 @@ class TraderDetailsServiceSpec
     reset(mockConnector)
   }
 
-  private val app = GuiceApplicationBuilder()
+  private val app: Application = applicationBuilder
     .overrides(inject.bind[ETMPConnector].toInstance(mockConnector))
     .build()
 


### PR DESCRIPTION
- Disable `PlayMongoModule` in unit tests so they can run without Mongo