### PR TITLE
DDCE-4874: Remove unused goodsName field in Applications

### DIFF
--- a/app/uk/gov/hmrc/advancevaluationrulings/controllers/UserAnswersInternalController.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/controllers/UserAnswersInternalController.scala
@@ -44,7 +44,7 @@ class UserAnswersInternalController @Inject() (
 
   private def authorised(action: IAAction) = auth.authorizedAction(predicate(action))
 
-  def get(draftId: DraftId): Action[AnyContent] = authorised(IAAction("READ")).async { implicit request =>
+  def get(draftId: DraftId): Action[AnyContent] = authorised(IAAction("READ")).async {
     repository
       .get(draftId)
       .map {

--- a/app/uk/gov/hmrc/advancevaluationrulings/models/application/ApplicationSummary.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/models/application/ApplicationSummary.scala
@@ -24,7 +24,7 @@ import java.time.Instant
 
 final case class ApplicationSummary(
   id: ApplicationId,
-  goodsName: String,
+  goodsDescription: String,
   dateSubmitted: Instant,
   eoriNumber: String
 )
@@ -34,7 +34,7 @@ object ApplicationSummary {
   val mongoReads: Reads[ApplicationSummary] =
     (
       (__ \ "id").read[ApplicationId] and
-        (__ \ "goodsDetails" \ "goodsName").read[String] and
+        (__ \ "goodsDetails" \ "goodsDescription").read[String] and
         (__ \ "created").read[Instant](MongoJavatimeFormats.instantFormat) and
         (__ \ "trader" \ "eori").read[String]
     )(ApplicationSummary.apply _)

--- a/app/uk/gov/hmrc/advancevaluationrulings/models/application/DraftSummary.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/models/application/DraftSummary.scala
@@ -23,7 +23,7 @@ import java.time.Instant
 
 final case class DraftSummary(
   id: DraftId,
-  goodsName: Option[String],
+  goodsDescription: Option[String],
   lastUpdated: Instant,
   eoriNumber: Option[String]
 )
@@ -35,7 +35,7 @@ object DraftSummary {
   def apply(answers: UserAnswers): DraftSummary =
     DraftSummary(
       id = answers.draftId,
-      goodsName = Reads
+      goodsDescription = Reads
         .optionNoError(Reads.at[String](JsPath \ "goodsDescription"))
         .reads(answers.data)
         .getOrElse(None),

--- a/app/uk/gov/hmrc/advancevaluationrulings/models/application/GoodsDetails.scala
+++ b/app/uk/gov/hmrc/advancevaluationrulings/models/application/GoodsDetails.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.advancevaluationrulings.models.application
 import play.api.libs.json.{Json, OFormat}
 
 final case class GoodsDetails(
-  goodsName: String,
   goodsDescription: String,
   envisagedCommodityCode: Option[String],
   knownLegalProceedings: Option[String],

--- a/it/uk/gov/hmrc/advancevaluationrulings/repositories/ApplicationRepositorySpec.scala
+++ b/it/uk/gov/hmrc/advancevaluationrulings/repositories/ApplicationRepositorySpec.scala
@@ -30,7 +30,7 @@ class ApplicationRepositorySpec
 
   private val trader              =
     TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None, Some(true))
-  private val goodsDetails        = GoodsDetails("name", "description", None, None, None, None, None)
+  private val goodsDetails        = GoodsDetails("description", None, None, None, None, None)
   private val submissionReference = "submissionReference"
   private val method              = MethodOne(None, None, None)
   private val contact             = ContactDetails("name", "email", None, None, None)
@@ -208,8 +208,8 @@ class ApplicationRepositorySpec
       val result = repository.summaries(eori1).futureValue
 
       result must contain theSameElementsAs Seq(
-        ApplicationSummary(ApplicationId(1), "name", now, "eori"),
-        ApplicationSummary(ApplicationId(2), "name", now, "eori")
+        ApplicationSummary(ApplicationId(1), "description", now, "eori"),
+        ApplicationSummary(ApplicationId(2), "description", now, "eori")
       )
     }
   }

--- a/test/uk/gov/hmrc/advancevaluationrulings/controllers/ApplicationControllerSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/controllers/ApplicationControllerSpec.scala
@@ -57,7 +57,7 @@ class ApplicationControllerSpec
   )
   private val trader              =
     TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None, Some(true))
-  private val goodsDetails        = GoodsDetails("name", "description", None, None, None, None, None)
+  private val goodsDetails        = GoodsDetails("description", None, None, None, None, None)
   private val submissionReference = "submissionReference"
   private val method              = MethodOne(None, None, None)
   private val contact             = ContactDetails("name", "email", None, None, None)

--- a/test/uk/gov/hmrc/advancevaluationrulings/models/application/ApplicationRequestSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/models/application/ApplicationRequestSpec.scala
@@ -91,7 +91,6 @@ object ApplicationRequestSpec extends Generators {
   )
 
   val goodsDetails: GoodsDetails = GoodsDetails(
-    goodsName = randomString,
     goodsDescription = randomString,
     similarRulingGoodsInfo = Some(randomString),
     similarRulingMethodInfo = Some(randomString),
@@ -101,7 +100,6 @@ object ApplicationRequestSpec extends Generators {
   )
 
   val goodsDetailsNoDetails: GoodsDetails = GoodsDetails(
-    goodsName = randomString,
     goodsDescription = randomString,
     similarRulingGoodsInfo = None,
     similarRulingMethodInfo = None,
@@ -136,7 +134,6 @@ object ApplicationRequestSpec extends Generators {
     |  "type" : "MethodThree"
     |},
     |"goodsDetails": {
-    |  "goodsName": "$randomString",
     |  "goodsDescription": "$randomString",
     |  "envisagedCommodityCode": "$randomString",
     |  "knownLegalProceedings": "$randomString",

--- a/test/uk/gov/hmrc/advancevaluationrulings/models/application/RoleHelperSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/models/application/RoleHelperSpec.scala
@@ -26,7 +26,7 @@ class RoleHelperSpec extends AnyFreeSpec with Matchers {
 
   private val trader: TraderDetail       =
     TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None, Some(true))
-  private val goodsDetails: GoodsDetails = GoodsDetails("name", "description", None, None, None, None, None)
+  private val goodsDetails: GoodsDetails = GoodsDetails("description", None, None, None, None, None)
   private val method: MethodOne          = MethodOne(None, None, None)
   private val contact: ContactDetails    = ContactDetails("name", "email", None, None, None)
   private val now: Instant               = Instant.now.truncatedTo(ChronoUnit.MILLIS)

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/ApplicationServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/ApplicationServiceSpec.scala
@@ -53,7 +53,7 @@ class ApplicationServiceSpec
   private val fixedClock                     = Clock.fixed(fixedInstant, ZoneId.systemDefault())
   private val trader                         =
     TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None, Some(true))
-  private val goodsDetails                   = GoodsDetails("name", "description", None, None, None, None, None)
+  private val goodsDetails                   = GoodsDetails("description", None, None, None, None, None)
   private val submissionReference            = "submissionReference"
   private val method                         = MethodOne(None, None, None)
   private val contact                        = ContactDetails("name", "email", None, None, None)

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/AuditServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/AuditServiceSpec.scala
@@ -55,7 +55,7 @@ class AuditServiceSpec extends AnyFreeSpec with SpecBase with MockitoSugar with 
 
   private val trader       =
     TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None, Some(false))
-  private val goodsDetails = GoodsDetails("name", "description", None, None, None, None, None)
+  private val goodsDetails = GoodsDetails("description", None, None, None, None, None)
   private val method       = MethodOne(None, None, None)
   private val contact      = ContactDetails("name", "email", None, None, None)
   private val now          = Instant.now.truncatedTo(ChronoUnit.MILLIS)

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/DefaultDmsSubmissionServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/DefaultDmsSubmissionServiceSpec.scala
@@ -65,7 +65,7 @@ class DefaultDmsSubmissionServiceSpec extends SpecBase with MockitoSugar with Be
 
     val trader              =
       TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None, Some(false))
-    val goodsDetails        = GoodsDetails("name", "description", None, None, None, None, None)
+    val goodsDetails        = GoodsDetails("description", None, None, None, None, None)
     val method              = MethodOne(None, None, None)
     val contact             = ContactDetails("name", "email", None, Some("Bob Inc"), Some("CEO"))
     val submissionReference = "submissionReference"

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/FopServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/FopServiceSpec.scala
@@ -36,45 +36,56 @@ class FopServiceSpec extends AnyFreeSpec with SpecBase with IntegrationPatience 
   private val app: api.Application   = applicationBuilder.build()
   private val fopService: FopService = app.injector.instanceOf[FopService]
 
-  private val attmts: Seq[Attachment] = Seq(
+  private val attachmentId: Int    = 12345
+  private val attachmentSize: Long = 12345L
+
+  private val attachments: Seq[Attachment] = Seq(
     Attachment(
-      12345,
+      attachmentId,
       "SomeFile1",
       Some("description of file"),
       "someLocation",
       Confidential,
       "pdf",
-      12345
+      attachmentSize
     ),
     Attachment(
-      12345,
+      attachmentId,
       "SomeFile2",
       Some("description of file"),
       "someLocation",
       Public,
       "pdf",
-      12345
+      attachmentSize
     ),
     Attachment(
-      12345,
+      attachmentId,
       "SomeFile3",
       Some("description of file"),
       "someLocation",
       Confidential,
       "pdf",
-      12345
+      attachmentSize
     )
   )
 
   private val letterOfAuthority: Attachment = Attachment(
-    12345,
+    attachmentId,
     "SomeFile3",
     Some("description of file"),
     "someLocation",
     Confidential,
     "pdf",
-    12345
+    attachmentSize
   )
+
+  private val longSampleText: String =
+    """Lorem ipsum dolor sit amet. Sed internos corporis qui quod ipsum sit saepe dolores ab
+      | quas similique ut commodi tempora et facilis porro ut officiis nihil.
+      |
+      |Ut eveniet assumenda sit quod fugit ut quae illo est amet iste. Ab nulla quia aut ipsam
+      | cumque aut aspernatur enim hic maiores voluptas aut dolores repudiandae eum maxim
+      | odio. In nesciunt mollitia quo reprehenderit natus qui soluta sequi.""".stripMargin
 
   "render" - {
 
@@ -87,7 +98,7 @@ class FopServiceSpec extends AnyFreeSpec with SpecBase with IntegrationPatience 
     "must generate a test PDF" in {
 
       val application = Application(
-        id = ApplicationId(25467987),
+        id = ApplicationId(attachmentId),
         applicantEori = "GB905360708861",
         trader = TraderDetail(
           eori = "GB905360708861",
@@ -121,28 +132,19 @@ class FopServiceSpec extends AnyFreeSpec with SpecBase with IntegrationPatience 
           jobTitle = Some("CEO")
         ),
         requestedMethod = MethodOne(
-          saleBetweenRelatedParties = Some(
-            "Lorem ipsum dolor sit amet. Sed internos corporis qui quod ipsum sit saepe dolores ab quas similique ut commodi tempora et facilis porro ut officiis nihil.\n\nUt eveniet assumenda sit quod fugit ut quae illo est amet iste. Ab nulla quia aut ipsam cumque aut aspernatur enim hic maiores voluptas aut dolores repudiandae eum maxime odio. In nesciunt mollitia quo reprehenderit natus qui soluta sequi."
-          ),
-          goodsRestrictions = Some(
-            "Lorem ipsum dolor sit amet. Sed internos corporis qui quod ipsum sit saepe dolores ab quas similique ut commodi tempora et facilis porro ut officiis nihil.\n\nUt eveniet assumenda sit quod fugit ut quae illo est amet iste. Ab nulla quia aut ipsam cumque aut aspernatur enim hic maiores voluptas aut dolores repudiandae eum maxime odio. In nesciunt mollitia quo reprehenderit natus qui soluta sequi."
-          ),
-          saleConditions = Some(
-            "Lorem ipsum dolor sit amet. Sed internos corporis qui quod ipsum sit saepe dolores ab quas similique ut commodi tempora et facilis porro ut officiis nihil."
-          )
+          saleBetweenRelatedParties = Some(longSampleText),
+          goodsRestrictions = Some(longSampleText),
+          saleConditions = Some(longSampleText)
         ),
         goodsDetails = GoodsDetails(
-          goodsName = "The name for the goods",
           goodsDescription = "A short description of the goods",
           similarRulingMethodInfo = Some("method info"),
           similarRulingGoodsInfo = Some("goods info"),
           envisagedCommodityCode = Some("070190"),
-          knownLegalProceedings = Some(
-            "Lorem ipsum dolor sit amet. Sed internos corporis qui quod ipsum sit saepe dolores ab quas similique ut commodi tempora et facilis porro ut officiis nihil.\n\nUt eveniet assumenda sit quod fugit ut quae illo est amet iste. Ab nulla quia aut ipsam cumque aut aspernatur enim hic maiores voluptas aut dolores repudiandae eum maxime odio. In nesciunt mollitia quo reprehenderit natus qui soluta sequi."
-          ),
+          knownLegalProceedings = Some(longSampleText),
           confidentialInformation = Some("Some confidential information")
         ),
-        attachments = attmts,
+        attachments = attachments,
         whatIsYourRoleResponse = Some(WhatIsYourRole.EmployeeOrg),
         letterOfAuthority = Some(letterOfAuthority),
         submissionReference = "submissionReference",

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/SaveFileDmsSubmissionServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/SaveFileDmsSubmissionServiceSpec.scala
@@ -64,7 +64,7 @@ class SaveFileDmsSubmissionServiceSpec extends SpecBase with BeforeAndAfterEach 
 
     val trader              =
       TraderDetail("eori", "name", "line1", None, None, "postcode", "GB", None, Some(false))
-    val goodsDetails        = GoodsDetails("name", "description", None, None, None, None, None)
+    val goodsDetails        = GoodsDetails("description", None, None, None, None, None)
     val method              = MethodOne(None, None, None)
     val contact             = ContactDetails("name", "email", None, Some("Bob Inc"), Some("CEO"))
     val submissionReference = "submissionReference"


### PR DESCRIPTION
- `goodsName` and `goodsDescription` fields in `GoodsDetails` of an application were storing the exact same data from the DescriptionOfGoodsPage