### PR TITLE
DDCE-5506: Fix page breaks in Apache FOP PDF generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ JRE/JDK 11 is recommended.
 The service also depends on mongodb.
 
 ## Running the service
-Using service manager (sm or sm2)
+Using service manager
 Use the ARS_ALL profile to bring up all services using the latest tagged releases
 
 ```bash

--- a/app/uk/gov/hmrc/advancevaluationrulings/views/Line.scala.xml
+++ b/app/uk/gov/hmrc/advancevaluationrulings/views/Line.scala.xml
@@ -1,14 +1,18 @@
 @this()
 
-@(key: String, value: String)(implicit messages: Messages)
+        @(key: String, value: String)(implicit messages: Messages)
 
-<fo:block border-bottom-width="1pt" border-bottom-style="solid" margin-top="1mm" margin-bottom="1mm" border-bottom-color="gray" padding-top="1mm" padding-bottom="1mm">
-    <fo:inline-container width="5cm">
-        <fo:block font-weight="bold">@messages(key)</fo:block>
-    </fo:inline-container>
-    <fo:inline-container width="12cm" margin-left="1cm">
-        @value.split('\n').map { line =>
+<fo:list-block border-bottom-width="1pt" border-bottom-style="solid" margin-top="1mm" margin-bottom="1mm" border-bottom-color="gray" padding-top="1mm" padding-bottom="1mm" provisional-label-separation="20pt" provisional-distance-between-starts="34%">
+    <fo:list-item>
+        <fo:list-item-label end-indent="label-end()">
+            <fo:block font-weight="bold">
+                @messages(key)
+            </fo:block>
+        </fo:list-item-label>
+        <fo:list-item-body start-indent="body-start()">
+            @value.split('\n').map { line =>
             <fo:block margin-bottom="3mm">@(line)</fo:block>
-        }
-    </fo:inline-container>
-</fo:block>
+            }
+        </fo:list-item-body>
+    </fo:list-item>
+</fo:list-block>

--- a/app/uk/gov/hmrc/advancevaluationrulings/views/Line.scala.xml
+++ b/app/uk/gov/hmrc/advancevaluationrulings/views/Line.scala.xml
@@ -1,6 +1,6 @@
 @this()
 
-        @(key: String, value: String)(implicit messages: Messages)
+@(key: String, value: String)(implicit messages: Messages)
 
 <fo:list-block border-bottom-width="1pt" border-bottom-style="solid" margin-top="1mm" margin-bottom="1mm" border-bottom-color="gray" padding-top="1mm" padding-bottom="1mm" provisional-label-separation="20pt" provisional-distance-between-starts="34%">
     <fo:list-item>

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,7 @@ object AppDependencies {
     "uk.gov.hmrc"             %% "bootstrap-backend-play-30"    % hmrcBootstrapPlayVersion,
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-30"           % hmrcMongoPlayVersion,
     "com.beachape"            %% "enumeratum-play-json"         % "1.8.0",
-    "org.typelevel"           %% "cats-core"                    % "2.10.0",
+    "org.typelevel"           %% "cats-core"                    % "2.12.0",
     "org.apache.xmlgraphics"   % "fop"                          % "2.9",
     "uk.gov.hmrc"             %% "crypto-json-play-30"          % "8.0.0",
     "uk.gov.hmrc"             %% "internal-auth-client-play-30" % "2.0.0",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ resolvers += Resolver.url(
   url("https://open.artefacts.tax.service.gov.uk/ivy2")
 )(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.21.0")
+addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.22.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.5.0")
 addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.3")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"         % "2.0.11")

--- a/test/uk/gov/hmrc/advancevaluationrulings/services/FopServiceSpec.scala
+++ b/test/uk/gov/hmrc/advancevaluationrulings/services/FopServiceSpec.scala
@@ -181,7 +181,7 @@ class FopServiceSpec extends AnyFreeSpec with SpecBase with IntegrationPatience 
         val lines: List[String] = text.split("\n").toList.map(_.trim)
 
         lines.headOption mustBe Some("Advance Valuation Ruling")
-        lines.length mustBe 136
+        lines.length mustBe 122
       }
     }
   }


### PR DESCRIPTION
Tested locally. 

I conducted local testing and took screenshots to document the results. In some text fields, large amounts of text were previously truncated and lost at the end of each page. After applying the fix, the text now correctly adheres to page margins and continues onto subsequent pages.

Since the fix impacts each line of the PDF, I compared the layout of the new, fixed PDF with the previous version. Everything appears to be functioning correctly.

<img width="506" alt="Screenshot 2024-05-29 at 15 44 13" src="https://github.com/hmrc/advance-valuation-rulings/assets/11977337/bab31aae-ab67-4f11-9d76-f154c550803c">

<img width="271" alt="Screenshot 2024-05-29 at 15 46 56" src="https://github.com/hmrc/advance-valuation-rulings/assets/11977337/c107e4ea-7411-498b-8d07-9465e7ee3ed6">


